### PR TITLE
adding code snipptes section

### DIFF
--- a/source/community.rst
+++ b/source/community.rst
@@ -22,6 +22,11 @@ Apps
 
 -   `Bomb Risk Elicitation Task (BRET) <http://www.sciencedirect.com/science/article/pii/S2214635016300120>`__ by Felix Holzmeister
 
+Code snippets
+----
+- `Making punishment field with binary choice and integer field
+<https://github.com/chapkovski/yes-no-punishment>`__
+
 Help & discussion mailing list
 ------------------------------
 


### PR DESCRIPTION
I added  a section to 'community resources' where some code snippets can be shown, that can be later reused by others.