### PR TITLE
Fix double colons causing incorrect code block start

### DIFF
--- a/source/tutorial/part1.rst
+++ b/source/tutorial/part1.rst
@@ -26,7 +26,7 @@ Create the app
 Use your command line to ``cd`` to the oTree project folder you created,
 the one that contains ``requirements_base.txt``.
 
-Then, create the app::
+Then, create the app:
 
 .. code-block:: bash
 


### PR DESCRIPTION
In the tutorial page for Public goods game, double colons in "Create the app" section is causing the code block to start in an incorrect position.

![image](https://user-images.githubusercontent.com/1064036/49683543-cb16f180-fa7b-11e8-9442-65530ef8259c.png)

https://otree.readthedocs.io/en/latest/tutorial/part1.html