### PR TITLE
Remove unused, unclosed <p> tag in Choice.html

### DIFF
--- a/source/tutorial/part3.rst
+++ b/source/tutorial/part3.rst
@@ -260,8 +260,6 @@ Django template language.
             At the end, a random round will be chosen for payment.
         </p>
 
-        <p>
-
         <h4>Round history</h4>
         <table class="table">
             <tr>


### PR DESCRIPTION
Choice.html contains a <p> tag that is unused and unclosed. No functional issue, a minor fix.