### PR TITLE
Added closer description of the migration process

### DIFF
--- a/source/misc/advanced.rst
+++ b/source/misc/advanced.rst
@@ -311,6 +311,8 @@ If your database already contains data and you want to update the structure
 without running ``resetdb`` (which will delete existing data), you can use Django's migrations feature.
 Below is a quick summary; for full info see the Django docs `here <https://docs.djangoproject.com/en/2.2/topics/migrations/#workflow>`__.
 
+Importantly, these first steps have to be taken before you add any new fields to your database. If you have already added variables to your ``models.py`` files, comment them out before starting this process.
+
 First, add an empty file ``otree_core_migrations/__init__.py``
 in your project top-level folder.
 
@@ -323,17 +325,24 @@ Then run::
     python manage.py makemigrations otree
 
 Then run ``python manage.py makemigrations my_app_name`` (substituting your app's name),
-for each app you are working on. This will create a ``migrations`` folder in your app,
-which you should add to your git repo, commit, and push to your server.
+for each app you are working on. This will create a ``migrations`` folder in your app.
+Add this as well as the ``otree_core_migrations/__init__.py`` to your git repo, commit, and push to your server.
 
-Instead of using ``otree resetdb`` on the server, run ``python manage.py migrate`` (or ``otree migrate``).
-If using Heroku, you would do ``heroku run otree migrate``.
+Instead of using ``otree resetdb`` on the server, run ``python manage.py migrate --fake`` (or ``otree migrate --fake``).
+If using Heroku, you would do ``heroku run otree migrate --fake``.
+This tells django to add these migrations to the list of applied migrations. Since nothing in your database has changed so far, it should not try to actually apply them however, hence the ``--fake``.
+
+You can now make your database relevant changes locally (or uncomment the fields). Once you're done, run ``otree makemigrations`` again. The console output should reflect the changes you have made. A new migrations file will appear in your apps migrations folder. Again, add this to git, commit and push.
+
+Now, on the server, you can run ``otree migrate your_app_name``.
 This will update your database tables.
 
 If you make further modifications to your apps or upgrade otree, you can run
 ``python manage.py makemigrations``. You don't need to specify the app names in this command;
 migrations will be updated for every app that has a ``migrations`` folder.
 Then commit, push, and run ``python manage.py migrate`` again as described above.
+
+The migration files build on each other which means you should not delete your local copies of the files from the git repo as django might otherwise be unable to detect what has changed.
 
 More info `here <https://docs.djangoproject.com/en/2.2/topics/migrations/#workflow>`__
 


### PR DESCRIPTION
Hey, I recently had the situation where I had to migrate a database using oTree.
The docs where a great kickstart but I still had to go pretty deep into djangos migration documentation to actually understand what I was doing wrong.
I think adding these few sentences doesn't blow up the docs too much and might help others learn from my mistakes.