### PR TITLE
Fix reference to static files in advanced.rst

### DIFF
--- a/source/misc/advanced.rst
+++ b/source/misc/advanced.rst
@@ -81,7 +81,7 @@ set ``template_name``. Example:
 CSS/JS and base templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To include the same JS/CSS in all pages of an app, either put it in a ref:`static file <staticfiles>`
+To include the same JS/CSS in all pages of an app, either put it in a :ref:`static file <staticfiles>`
 or put it in an includable template.
 
 .. _staticfiles:


### PR DESCRIPTION
I noticed that there is a broken reference in the docs which is fixed by this (very minimalistic) PR.